### PR TITLE
Fix highlighting in PR diffs. Observe PR diff expansion and rewrap nodes. Fixes #9.

### DIFF
--- a/src/highlight-selected.js
+++ b/src/highlight-selected.js
@@ -1,5 +1,5 @@
 window.addEventListener('load', function() {
-    var container = '.blob-wrapper';
+    var container = '.blob-wrapper, .js-blob-wrapper';
     var lastPage = location.href;
     var textNodes = [];
     var highlighted = [];
@@ -39,6 +39,16 @@ window.addEventListener('load', function() {
         textNodes.reverse();
     }
 
+    function observePullRequestDiffs(mutationObserverOptions) {
+        var diffExpandMutationObserver = new MutationObserver(function(mutationRecords) {
+            wrapTextNodes(container);
+        });
+        var diffTables = document.querySelectorAll('.diff-table > tbody');
+        for (var diffTable of diffTables) {
+            diffExpandMutationObserver.observe(diffTable, mutationObserverOptions);
+        }
+    }
+
     wrapTextNodes(container);
 
     // watch for page updating...
@@ -52,9 +62,11 @@ window.addEventListener('load', function() {
         if (location.href != lastPage) {
             lastPage = location.href;
             wrapTextNodes(container);
+            observePullRequestDiffs(whatToObserve);
         }
     });
     mutationObserver.observe(document.querySelector('#js-repo-pjax-container'), whatToObserve);
+    observePullRequestDiffs(whatToObserve);
 
     function restore() {
         highlighted.forEach(function(el) {


### PR DESCRIPTION
Hi @xhacker, as I mentioned in #9, in the spirit of [Hacktoberfest](https://hacktoberfest.digitalocean.com) I wanted to contribute to this extension, which I use every day and find extremely useful!

I have tackled fixing highlighting in pull requests using two techniques:
- Adding class `js-blob-wrapper` to classes where highlighting is applied, since this class is used in PR pages.
- Creating an additional `MutationObserver` to observe PR code diffs, so that when you click the arrows to expand the diffs, the new nodes will be wrapped for highlighting as well.

Here is an example of the highlighting working in a pull request's diff view, in the expanded part of a diff: <img width="847" alt="highlights-in-pr-diff" src="https://user-images.githubusercontent.com/6874678/46713093-206c8900-cc1a-11e8-95f6-2633ba978544.png">

Please let me know what you think, and thanks again for this great Chrome extension!