### PR TITLE
Add support for gists. Fixes #14.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
 
   "content_scripts": [ {
     "js": [ "src/highlight-selected.js" ],
-    "matches": [ "https://github.com/*" ]
+    "matches": [ "https://github.com/*", "https://gist.github.com/*" ]
   } ],
   "minimum_chrome_version": "20",
   "permissions": [

--- a/src/highlight-selected.js
+++ b/src/highlight-selected.js
@@ -65,7 +65,9 @@ window.addEventListener('load', function() {
             observePullRequestDiffs(whatToObserve);
         }
     });
-    mutationObserver.observe(document.querySelector('#js-repo-pjax-container'), whatToObserve);
+    var codeContainer = document.querySelector('#js-repo-pjax-container');
+    if (!codeContainer) codeContainer = document.querySelector('#gist-pjax-container'); // for gists
+    mutationObserver.observe(codeContainer, whatToObserve);
     observePullRequestDiffs(whatToObserve);
 
     function restore() {


### PR DESCRIPTION
In the spirit of [Hacktoberfest](https://hacktoberfest.digitalocean.com/), here is a PR that addresses #14.

I have tested it and it works on gists now. The main change was adding support for another pjax container, `gist-pjax-container`.

Let me know if you'd like any further changes. Thanks!